### PR TITLE
Implemented Food System

### DIFF
--- a/game/domain/character.go
+++ b/game/domain/character.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"fmt"
+	"image"
 	_ "image/png"
 	"math"
 
@@ -62,14 +63,15 @@ type Character struct {
 
 // contains the common character traits between players and enemies
 type CharacterInstance struct {
-	Direction int
-	Frame     int
-	IsMoving  bool
-	X         int
-	Y         int
-	MoveSpeed float64
-	Width     int
-	Height    int
+	Direction        int
+	Frame            int
+	IsMoving         bool
+	X                int
+	Y                int
+	MoveSpeed        float64
+	MoveSpeedPenalty float64 // 0.0 is full speed. Single multiplier for now, can make more robust with an array later.
+	Width            int
+	Height           int
 
 	moveRemainderX float64
 	moveRemainderY float64
@@ -77,14 +79,36 @@ type CharacterInstance struct {
 }
 
 func (c *CharacterInstance) Update(dirBits int) {
-	if dirBits == 0 {
+	c.UpdateWithCollision(dirBits, func(image.Point) bool {
+		return false
+	})
+}
+
+func (c *CharacterInstance) UpdateWithCollision(dirBits int, isBlocked func(image.Point) bool) {
+	if dirBits == 0 || !c.canMove(dirBits, isBlocked) {
 		c.IsMoving = false
 		c.animationTicks = 0
 		return
 	}
 	c.IsMoving = true
 	c.Direction = directionToSpriteIndex(dirBits)
+	dx, dy := c.movementDelta(dirBits)
+	if dx != 0 {
+		moveCoordinate(&c.X, &c.moveRemainderX, dx)
+	}
+	if dy != 0 {
+		moveCoordinate(&c.Y, &c.moveRemainderY, dy)
+	}
+	c.animationTicks++
+	if c.animationTicks >= updatesPerWalkingFrame {
+		c.Frame = (c.Frame + 1) % SpriteCols
+		c.animationTicks = 0
+	}
+}
+
+func (c *CharacterInstance) movementDelta(dirBits int) (float64, float64) {
 	dx, dy := 0, 0
+
 	if dirBits&DirLeft != 0 {
 		dx--
 	}
@@ -97,21 +121,22 @@ func (c *CharacterInstance) Update(dirBits int) {
 	if dirBits&DirUp != 0 {
 		dy--
 	}
-	distance := c.MoveSpeed
+
+	distance := c.activeMoveSpeed()
 	if dx != 0 && dy != 0 {
 		distance *= diagonalMovementScale
 	}
-	if dx != 0 {
-		moveCoordinate(&c.X, &c.moveRemainderX, float64(dx)*distance)
-	}
-	if dy != 0 {
-		moveCoordinate(&c.Y, &c.moveRemainderY, float64(dy)*distance)
-	}
-	c.animationTicks++
-	if c.animationTicks >= updatesPerWalkingFrame {
-		c.Frame = (c.Frame + 1) % SpriteCols
-		c.animationTicks = 0
-	}
+
+	return float64(dx) * distance, float64(dy) * distance
+}
+
+func (c *CharacterInstance) canMove(dirBits int, isBlocked func(image.Point) bool) bool {
+	dx, dy := c.movementDelta(dirBits)
+
+	newX := c.X + int(math.Trunc(c.moveRemainderX+dx))
+	newY := c.Y + int(math.Trunc(c.moveRemainderY+dy))
+
+	return !isBlocked(image.Point{X: newX, Y: newY})
 }
 
 func moveCoordinate(position *int, remainder *float64, distance float64) {
@@ -207,4 +232,9 @@ func getEmbeddedFile(filename string) []byte {
 		return nil
 	}
 	return data
+}
+
+func (c *CharacterInstance) activeMoveSpeed() float64 {
+	penalty := max(0.0, min(1.0, c.MoveSpeedPenalty))
+	return c.MoveSpeed * (1.0 - penalty)
 }

--- a/game/domain/player.go
+++ b/game/domain/player.go
@@ -35,7 +35,7 @@ type Player struct {
 }
 
 const TravelDistancePerDay = 5000.0
-const TravelDistancePerFood = 150.0
+const TravelDistancePerFood = 450.0
 const StarvationSpeedPenalty = 0.5
 
 func NewPlayer(name string, visage *ebiten.Image, isM bool, difficulty Difficulty, color ColorMask) (*Player, error) {

--- a/game/domain/player.go
+++ b/game/domain/player.go
@@ -27,6 +27,7 @@ type Player struct {
 	ActiveQuests    []*Quest // active quests (legacy delivery/defeat + deck-changing), up to MaxActiveQuests
 	Days            int
 	TimeAccumulator float64
+	FoodAccumulator float64
 	IsMale          bool
 	BonusDuelLife   int
 	BonusDuelCards  []*Card // One-time bonus cards that start in play in the next duel
@@ -34,6 +35,8 @@ type Player struct {
 }
 
 const TravelDistancePerDay = 5000.0
+const TravelDistancePerFood = 150.0
+const StarvationSpeedPenalty = 0.5
 
 func NewPlayer(name string, visage *ebiten.Image, isM bool, difficulty Difficulty, color ColorMask) (*Player, error) {
 	sprite, err := imageutil.LoadSpriteSheet(5, 8, getEmbeddedFile("Ego_F.spr.png"))
@@ -143,22 +146,29 @@ func (p *Player) NumCards() int {
 	return p.CardCollection.NumCards()
 }
 
-func (p *Player) Update(screenW, screenH, levelW, levelH int) error {
+func (p *Player) Update(screenW, screenH, levelW, levelH int, isBlocked func(image.Point) bool) error {
 	oldX, oldY := p.X, p.Y
 	dirBits := p.Move(screenW, screenH)
-	p.CharacterInstance.Update(dirBits)
+	p.updateSpeedPenalty()
+	p.CharacterInstance.UpdateWithCollision(dirBits, isBlocked)
 
 	if p.X != oldX || p.Y != oldY {
 		// Player moved
 		dist := math.Sqrt(math.Pow(float64(p.X-oldX), 2) + math.Pow(float64(p.Y-oldY), 2))
 		p.TimeAccumulator += dist
-		if p.TimeAccumulator >= TravelDistancePerDay {
+		for p.TimeAccumulator >= TravelDistancePerDay {
 			p.TimeAccumulator -= TravelDistancePerDay
 			p.Days++
 			for _, q := range p.ActiveQuests {
 				q.DaysRemaining--
 			}
 			p.ExpireQuests()
+		}
+
+		p.FoodAccumulator += dist
+		for p.FoodAccumulator >= TravelDistancePerFood && p.Food > 0 {
+			p.FoodAccumulator -= TravelDistancePerFood
+			p.Food--
 		}
 	}
 
@@ -175,6 +185,17 @@ func (p *Player) Update(screenW, screenH, levelW, levelH int) error {
 	}
 
 	return nil
+}
+
+func (p *Player) updateSpeedPenalty() {
+	p.MoveSpeedPenalty = 0.0
+	if p.isStarving() {
+		p.MoveSpeedPenalty = StarvationSpeedPenalty
+	}
+}
+
+func (p *Player) isStarving() bool {
+	return p.Food == 0
 }
 
 func (p *Player) SetLoc(loc image.Point) {

--- a/game/world/level.go
+++ b/game/world/level.go
@@ -208,17 +208,15 @@ func (l *Level) UpdateWorld(screenW, screenH int) error {
 	l.totalTicks++
 	l.ticksSinceLastInteraction++
 
-	oldX, oldY := l.Player.X, l.Player.Y
-	oldTimeAccumulator := l.Player.TimeAccumulator
-	oldDays := l.Player.Days
-	if err := l.Player.Update(screenW, screenH, l.LevelW(), l.LevelH()); err != nil {
+	if err := l.Player.Update(
+		screenW,
+		screenH,
+		l.LevelW(),
+		l.LevelH(),
+		func(pos image.Point) bool {
+			return l.IsWaterAtPixel(pos)
+		}); err != nil {
 		return err
-	}
-	if l.IsWaterAtPixel(l.Player.Loc()) {
-		l.Player.X = oldX
-		l.Player.Y = oldY
-		l.Player.TimeAccumulator = oldTimeAccumulator
-		l.Player.Days = oldDays
 	}
 
 	for i := range l.Enemies {


### PR DESCRIPTION
* Food now ticks down at a rate of 1 per 150 distance, and player movement speed is halved when food reaches 0. (These are determined by constant values that can be changed.)
* Collision is now determined before a move is made, not after. This prevents a bug where days could pass or food could decrement with every attempted step against a water tile. Furthermore, the player will no longer animate when movement is not possible.
* Replaced the TimeAccumulator decrement block with a for loop for parity with the new FoodAccumulator block. This ensures that day increments/food decrements are never skipped when constants are set to low values.

NOTES

* Speed penalties are currently updated with every tick. This was intended for ease of implementation, but use of getters/setters can be enforced to reduce update checks if optimization is preferred. 
* The MoveSpeedPenalty variable is a single float, but implementation was intentionally deferred to separate functions to make altering this easy. e.g. If terrain movement penalties need be added in the feature, the functions can instead be altered to work with an array.